### PR TITLE
feat: add http header and http code

### DIFF
--- a/protoc-gen-go-http/http.go
+++ b/protoc-gen-go-http/http.go
@@ -18,6 +18,7 @@ const (
 	httpPackage          = protogen.GoImportPath("net/http")
 	restfulPackage       = protogen.GoImportPath("github.com/emicklei/go-restful")
 	jsonPackage          = protogen.GoImportPath("encoding/json")
+	kitErrorsPackage     = protogen.GoImportPath("github.com/tkeel-io/kit/errors")
 	transportHTTPPackage = protogen.GoImportPath("github.com/tkeel-io/kit/transport/http")
 )
 
@@ -50,9 +51,8 @@ func generateFileContent(gen *protogen.Plugin, file *protogen.File, g *protogen.
 	g.P("// This is a compile-time assertion to ensure that this generated file")
 	g.P("// is compatible with the tkeel package it is being compiled against.")
 	g.P("// import package.", contextPackage.Ident(""), httpPackage.Ident(""),
-		restfulPackage.Ident(""), jsonPackage.Ident(""))
+		restfulPackage.Ident(""), jsonPackage.Ident(""), kitErrorsPackage.Ident(""))
 	g.P("")
-	g.P("const _ = transportHTTP.ImportAndUsed")
 	for _, service := range file.Services {
 		genService(gen, file, g, service, omitempty)
 	}

--- a/protoc-gen-go-http/template.go
+++ b/protoc-gen-go-http/template.go
@@ -52,7 +52,7 @@ func (h *{{$svrType}}HTTPHandler) {{.Name}}(req *go_restful.Request, resp *go_re
 	}
 	{{- end}}
 
-	ctx := context.WithValue(req.Request.Context(), transportHTTP.ContextHTTPHeaderKey,
+	ctx := transportHTTP.ContextWithHeader(req.Request.Context(), transportHTTP.ContextHTTPHeaderKey,
 		req.Request.Header)
 
 	out,err := h.srv.{{.Name}}(ctx, &in)

--- a/protoc-gen-go-http/template.go
+++ b/protoc-gen-go-http/template.go
@@ -52,9 +52,14 @@ func (h *{{$svrType}}HTTPHandler) {{.Name}}(req *go_restful.Request, resp *go_re
 	}
 	{{- end}}
 
-	out,err := h.srv.{{.Name}}(req.Request.Context(), &in)
+	ctx := context.WithValue(req.Request.Context(), transportHTTP.ContextHTTPHeaderKey,
+		req.Request.Header)
+
+	out,err := h.srv.{{.Name}}(ctx, &in)
 	if err != nil {
-		resp.WriteErrorString(http.StatusInternalServerError, err.Error())
+		tErr := errors.FromError(err)
+		httpCode := errors.GRPCToHTTPStatusCode(tErr.GRPCStatus().Code())
+		resp.WriteErrorString(httpCode, tErr.Message)
 		return
 	}
 


### PR DESCRIPTION
1. Add the http header to the context parameter.
2. Add `TError` processing logic at the http protocol.