### PR TITLE
fix: fixed rander err @code=OK unuseable

### DIFF
--- a/protoc-gen-go-errors/render.go
+++ b/protoc-gen-go-errors/render.go
@@ -95,6 +95,9 @@ func generationErrorsSection(gen *protogen.Plugin, file *protogen.File, g *proto
 			Msg:             eMsg.val,
 			Key:             string(v.Desc.FullName()),
 		}
+		if err.Code == "Ok" {
+			err.Code = "OK"
+		}
 		ew.Errors = append(ew.Errors, err)
 	}
 	if len(ew.Errors) == 0 {


### PR DESCRIPTION
In file : `google.golang.org/grpc@v1.44.0/codes/codes.go` Defined the Code OK named `OK`, But gen Err Render function render `Ok`
// OK is returned on success.
const OK Code = 0 

	